### PR TITLE
[ADD] saas_initialization_script_template 

### DIFF
--- a/saas_initialization_script_template/README.rst
+++ b/saas_initialization_script_template/README.rst
@@ -1,0 +1,28 @@
+===================================
+Saas Initialization Script Template
+===================================
+
+Initialization script templates for prepopulating template initialization and build initialization
+
+Configuration
+=============
+
+No steps are required to configure this module.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to menu "Initialization Templates" in the SaaS settings menu.
+#. Create a template, choosing its type (Template initialization or build initializetion) and setting the initialization code. For build templates, it is also possible to set default script variables that will be automatically pre-populated in the build creation wizard
+#. When creating a new template select an initialization script template so that the initialization code is automatically set according to the selected template.
+
+Roadmap
+=======
+
+#. Having the possibility to select more than one script template, so that they concatenate to form the final initialization script.
+#. Validation if all preconfigured build variables are filled in
+
+Changelog
+=========

--- a/saas_initialization_script_template/__init__.py
+++ b/saas_initialization_script_template/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/saas_initialization_script_template/__manifest__.py
+++ b/saas_initialization_script_template/__manifest__.py
@@ -1,0 +1,23 @@
+# Copyright 2023 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Saas Initialization Script Template',
+    'description': """
+        Initialization script templates for prepopulating template initialization and build initialization""",
+    'version': '14.0.1.0.0',
+    'license': 'AGPL-3',
+    'author': 'KMEE',
+    'website': 'https://kmee.com.br/',
+    'depends': [
+        'saas',
+    ],
+    'data': [
+        "security/ir.model.access.csv",
+        'views/saas_initialization_template_views.xml',
+        'views/saas_template_views.xml',
+        'views/saas_view.xml',
+    ],
+    'demo': [
+    ],
+}

--- a/saas_initialization_script_template/models/__init__.py
+++ b/saas_initialization_script_template/models/__init__.py
@@ -1,0 +1,2 @@
+from . import saas_initialization_template
+from . import saas_template

--- a/saas_initialization_script_template/models/saas_initialization_template.py
+++ b/saas_initialization_script_template/models/saas_initialization_template.py
@@ -1,0 +1,55 @@
+from odoo import models, fields
+
+DEFAULT_TEMPLATE_PYTHON_CODE = """# Available variables:
+#  - env: Odoo Environment on which the action is triggered
+#  - time, datetime, dateutil, timezone: useful Python libraries
+#  - log: log(message, level='info'): logging function to record debug information in ir.logging table
+#  - Warning: Warning Exception to use with raise
+# To return an action, assign: action = {...}\n\n\n\n"""
+
+DEFAULT_BUILD_PYTHON_CODE = """# Available variables:
+#  - env: Odoo Environment on which the action is triggered
+#  - time, datetime, dateutil, timezone: useful Python libraries
+#  - log: log(message, level='info'): logging function to record debug information in ir.logging table
+#  - Warning: Warning Exception to use with raise
+# To return an action, assign: action = {{...}}
+# You can specify places for variables that can be passed when creating a build like this:
+# env['{key_name_1}'].create({{'subject': '{key_name_2}', }})
+# When you need curly braces in build post init code use doubling for escaping\n\n\n\n"""
+
+
+INITIALIZATION_TYPE_SELECTION = [
+    ('template', 'Template'),
+    ('build', 'Build'),
+]
+
+
+class SAASInitializationTemplate(models.Model):
+    _name = 'saas.initialization.template'
+    _description = 'Initialization Template'
+
+    name = fields.Char(
+        string='Name'
+    )
+
+    initialization_type = fields.Selection(
+        string='Initialization Type',
+        selection=INITIALIZATION_TYPE_SELECTION,
+        default='build'
+    )
+
+    template_post_init = fields.Text(
+        'Template Initialization',
+        default=DEFAULT_TEMPLATE_PYTHON_CODE,
+        help='Python code to be executed once db is created and modules are installed')
+
+    build_post_init = fields.Text(
+        'Build Initialization',
+        default=DEFAULT_BUILD_PYTHON_CODE,
+        help='Python code to be executed once build db is created from template')
+
+    build_post_init_line_ids = fields.One2many(
+        'build.post_init.line', 'initializateion_template_id',
+        string="Build Initialization Values",
+        help="These values will be used on execution template's Build Initialization code"
+    )

--- a/saas_initialization_script_template/models/saas_template.py
+++ b/saas_initialization_script_template/models/saas_template.py
@@ -1,0 +1,27 @@
+from odoo import models, fields, api
+
+
+class SAASTemplate(models.Model):
+    _inherit = 'saas.template'
+
+    template_initialization_template_id = fields.Many2one(
+        comodel_name='saas.initialization.template',
+        string='Initialization Template'
+    )
+
+    build_initialization_template_id = fields.Many2one(
+        comodel_name='saas.initialization.template',
+        string='Build Initialization Template'
+    )
+
+    @api.onchange('template_initialization_template_id')
+    def onchange_initialization_template(self):
+        if self.template_initialization_template_id:
+            template_code = self.template_initialization_template_id.template_post_init
+            self.template_post_init = template_code
+
+    @api.onchange('build_initialization_template_id')
+    def onchange_build_initialization_template(self):
+        if self.build_initialization_template_id:
+            template_code = self.build_initialization_template_id.build_post_init
+            self.build_post_init = template_code

--- a/saas_initialization_script_template/security/ir.model.access.csv
+++ b/saas_initialization_script_template/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+user_access_saas_initialization_template,user_access_saas_initialization_template,model_saas_initialization_template,saas.group_user,1,0,0,0
+manager_access_saas_initialization_template,manager_access_saas_initialization_template,model_saas_initialization_template,saas.group_manager,1,1,1,1

--- a/saas_initialization_script_template/views/saas_initialization_template_views.xml
+++ b/saas_initialization_script_template/views/saas_initialization_template_views.xml
@@ -1,0 +1,41 @@
+<odoo>
+    <record id='saas_initialization_template_view_tree' model='ir.ui.view'>
+        <field name="name">saas.initialization.template.tree</field>
+        <field name="model">saas.initialization.template</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" string="Template Name" />
+                <field name="initialization_type"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="saas_initialization_template_form_view" model="ir.ui.view">
+        <field name="name">saas.initialization.template.form</field>
+        <field name="model">saas.initialization.template</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="initialization_type"/>
+                        <field name="template_post_init" widget="ace" options="{'mode': 'python'}" attrs="{'invisible': [('initialization_type','!=', 'template')]}"/>
+                        <field name="build_post_init" widget="ace" options="{'mode': 'python'}" attrs="{'invisible': [('initialization_type','!=', 'build')]}"/>
+                        <field name='build_post_init_line_ids' attrs="{'invisible': [('initialization_type','!=', 'build')]}">
+                        <tree editable='bottom'>
+                            <field name='key'/>
+                                <field name='value'/>
+                            </tree>
+                            <form string='Build post init form'>
+                                <group>
+                                    <field name='key'/>
+                                    <field name='value'/>
+                                </group>
+                            </form>
+                        </field>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/saas_initialization_script_template/views/saas_template_views.xml
+++ b/saas_initialization_script_template/views/saas_template_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="saas_template_form_view" model="ir.ui.view">
+        <field name="name">saas.template.form.view</field>
+        <field name="model">saas.template</field>
+        <field name="inherit_id" ref="saas.saas_template_form_view" />
+        <field name="arch" type="xml">
+            <field name="template_post_init" position='before'>
+                <field name='template_initialization_template_id' domain="[('initialization_type','=','template')]"/>
+            </field>
+            <field name="build_post_init" position='before'>
+                <field name='build_initialization_template_id' domain="[('initialization_type','=','build')]"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/saas_initialization_script_template/views/saas_view.xml
+++ b/saas_initialization_script_template/views/saas_view.xml
@@ -1,0 +1,20 @@
+
+<!--# Copyright 2019 Denis Mudarisov <https://www.it-projects.info/team/trojikman>
+    # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).-->
+
+<odoo>
+    <!-- Actions   -->
+    <record model='ir.actions.act_window' id="saas_initialization_template_action" >
+        <field name="name">Initialization Templates</field>
+        <field name="res_model">saas.initialization.template</field>
+        <field name="views">[(False, 'form')]</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <!-- Menu items-->
+    <menuitem name="Initialization Templates"
+              parent="saas.saas_main_menu_config"
+              id="saas_menu_config_initialization_template"
+              sequence="20"
+              action="saas_initialization_template_action"/>
+</odoo>

--- a/saas_initialization_script_template/wizard/__init__.py
+++ b/saas_initialization_script_template/wizard/__init__.py
@@ -1,0 +1,2 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from . import saas_template_create_build

--- a/saas_initialization_script_template/wizard/saas_template_create_build.py
+++ b/saas_initialization_script_template/wizard/saas_template_create_build.py
@@ -1,0 +1,22 @@
+from odoo import api, models, fields
+
+
+class CreateBuildByTemplate(models.TransientModel):
+    _inherit = 'saas.template.create_build'
+
+    # build_post_init_ids = fields.One2many(compute='_compute_build_post_init_ids')
+
+    @api.onchange('template_id')
+    def _onchange_build_post_init_ids(self):
+        for rec in self:
+            build_template_id = rec.template_id.build_initialization_template_id
+            if build_template_id:
+                rec.build_post_init_ids = build_template_id.build_post_init_line_ids
+
+
+class BuildPostInit(models.TransientModel):
+    _inherit = 'build.post_init.line'
+    initializateion_template_id = fields.Many2one(
+        comodel_name='saas.initialization.template',
+        readonly=True
+    )

--- a/saas_initialization_script_template/wizard/saas_template_create_build_view.xml
+++ b/saas_initialization_script_template/wizard/saas_template_create_build_view.xml
@@ -1,0 +1,36 @@
+<!--# Copyright 2019 Denis Mudarisov <https://www.it-projects.info/team/trojikman>
+    # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).-->
+<odoo>
+    <record model="ir.ui.view" id="saas_template_create_build">
+        <field name="name">SaaS Template Create Build</field>
+        <field name="model">saas.template.create_build</field>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="build_name"/>
+                    <field name="template_id" invisible="1"/>
+                    <field name="template_operator_id" domain="[('template_id', '=', template_id), ('state', '=', 'done')]" attrs="{'invisible':[('random', '=', True)]}"/>
+                    <field name="template_operator_count" invisible="1"/>
+                    <field name="random" attrs="{'invisible':[('template_operator_count', 'in', [0, 1])]}"/>
+                    <field name='build_post_init_ids'>
+                        <tree editable='bottom'>
+                            <field name='key'/>
+                            <field name='value'/>
+                        </tree>
+                        <form string='Build post init form'>
+                            <group>
+                                <field name='key'/>
+                                <field name='value'/>
+                            </group>
+                        </form>
+                    </field>
+                </group>
+                <footer>
+                    <button string="Cancel" special="cancel" class="oe_highlight"/>
+                    <button name="create_build" string="Create Build" type="object" class="oe_highlight" />
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Esse PR
Adiciona o módulo saas_initialization_script_template visando melhorar a usabilidade dos scripts de inicialização de build e de templates para usuários não técnicos.
Com esse módulo, é possível criar templates de scripts e a relação de varáveis necessárias para eles, de modo que usuários não técnicos apenas precisem selecionar templates de scripts já pré-configurados e preencher a relação de variáveis já definidas ao criar um novo template de banco ou build.

## Como utilizar
- Acesse o menu "Initialization Templates" nas configurações do SaaS (SaaS -> Configurations -> Initialization Templates)
- Crie um novo template, podendo ser do tipo "Template" para scripts de templates de banco ou "Build" para scripts para builds. Para esse último tipo, também é possível configurar a relação de variáveis que o script possa usar.
- Ao criar um novo template de banco, selecione o template de script desejado para cada tipo, para que os campos de scripts de inicialização sejam pré populado, assim como a relação de variáveis ao abrir o wizard de criação de build.

cc: @mileo @Tiago370 